### PR TITLE
クローラー対策のため robots を動的にレスポンスできるようにする

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,6 +66,7 @@ jobs:
           DATABASE_URL: postgres://dbuser:mysecretpassword@localhost:5432/dbname
         run: |
           bundle install
-          npx playwright@1.32.2 install --force --with-deps chromium
+          npm install
+          npx playwright install --with-deps chromium
           bundle exec rails db:schema:load
           bundle exec rspec

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -11,5 +11,6 @@ class WelcomeController < ApplicationController
   end
 
   def robots
+    @disallowed_path = '/' unless ENV['ROBOTS_INDEX']
   end
 end

--- a/app/views/welcome/robots.text.erb
+++ b/app/views/welcome/robots.text.erb
@@ -1,1 +1,3 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: <%= @disallowed_path %>

--- a/spec/features/robots.feature
+++ b/spec/features/robots.feature
@@ -1,0 +1,15 @@
+Feature: 特定の環境変数を設定しなければ検索エンジンのインデックス登録を拒否すること
+  Background:
+    Given 環境変数"ROBOTS_INDEX"が未設定である
+
+  Scenario: 環境変数なし
+    When ブラウザで"/robots"にアクセスする
+    Then レスポンス形式が"text/plain"である
+    And レスポンス本文に"Disallow: /"とある
+
+  Scenario: 環境変数あり
+    When 環境変数"ROBOTS_INDEX"に"yes"を設定する
+
+    When ブラウザで"/robots"にアクセスする
+    Then レスポンス形式が"text/plain"である
+    And レスポンス本文に"Disallow: /"とない

--- a/spec/steps/robots_steps.rb
+++ b/spec/steps/robots_steps.rb
@@ -1,0 +1,23 @@
+step '環境変数:nameが未設定である' do |name|
+  ENV[name] = nil
+end
+
+step '環境変数:nameに:valueを設定する' do |name, value|
+  ENV[name] = value
+end
+
+step 'ブラウザで:visit_pathにアクセスする' do |visit_path|
+  visit(visit_path)
+end
+
+step 'レスポンス形式が:content_typeである' do |content_type|
+  assert page.response_headers['content-type'].include?(content_type)
+end
+
+step 'レスポンス本文に:contentとある' do |content|
+  assert_text(content)
+end
+
+step 'レスポンス本文に:contentとない' do |content|
+  assert_no_text(content)
+end


### PR DESCRIPTION
## 概要（実現したいこと・ユーザーストーリー）

#74

## 受け入れ条件

```
Feature: 特定の環境変数を設定しなければ検索エンジンのインデックス登録を拒否すること
  Background:
    Given 環境変数"ROBOTS_INDEX"が未設定である

  Scenario: 環境変数なし
    When ブラウザで"/robots"にアクセスする
    Then レスポンス形式が"text/plain"である
    And レスポンス本文に"Disallow: /"とある

  Scenario: 環境変数あり
    When 環境変数"ROBOTS_INDEX"に"yes"を設定する

    When ブラウザで"/robots"にアクセスする
    Then レスポンス形式が"text/plain"である
    And レスポンス本文に"Disallow: /"とない

```
