### PR TITLE
OpenId Connect による Google ID 認証を実装する

### DIFF
--- a/.rubocop/rails.yml
+++ b/.rubocop/rails.yml
@@ -62,6 +62,7 @@ Rails/DynamicFindBy:
   Enabled: true
   Whitelist:
     - find_by_sql
+    - find_by_hash_google_id
 
 Rails/EnumUniqueness:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ end
 
 gem "active_decorator"
 gem "active_hash"
+gem 'activerecord-session_store'
 gem "googleauth"
 gem "holiday_japan"
 gem "newspaper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,12 @@ GEM
     activerecord (7.0.4.3)
       activemodel (= 7.0.4.3)
       activesupport (= 7.0.4.3)
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
     activestorage (7.0.4.3)
       actionpack (= 7.0.4.3)
       activejob (= 7.0.4.3)
@@ -339,6 +345,7 @@ PLATFORMS
 DEPENDENCIES
   active_decorator
   active_hash
+  activerecord-session_store
   authentication-zero
   bcrypt (~> 3.1.7)
   bootsnap

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
 
 コンテナを起動し、セットアップコマンドを実行してください。
 
+> **Note**
+>
+> Google でログインを有効にする場合は [Google Cloud Console](https://console.cloud.google.com/) で「OAuth 同意画面」と「OAuth 2.0 クライアント ID」を設定してください。
+> その後 `.env` ファイルを作成し `GOOGLE_OPENID_CONNECT_CLIENT_ID` として値を設定してください。
+
 ```shell
 docker compose up -d
 docker compose exec rails bash

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,36 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_action :set_current_authenticated_user
+  before_action :set_current_state
 
   private
 
-  def set_current_authenticated_user
-    Current.user = User.find_by(id: cookies.signed[:user_id])
+  def set_current_state
+    reset_session unless current_session_id
+    Current.session = Session.find_by!(session_id: current_session_id)
+  end
+
+  def current_session_id
+    session.id&.private_id
+  end
+
+  def redirect_to_after_signin_url_if_registered_user?
+    user = Current.user
+
+    redirect_to user_url(id: user.id) if user&.registered?
+  end
+
+  def require_answerd_to_survey_profile_and_unregistered_user
+    user = Current.user
+    return if user && !user.registered?
+
+    redirect_to root_url
+  end
+
+  def signin_by(user)
+    # See: https://guides.rubyonrails.org/security.html#session-fixation
+    reset_session
+    Current.session = Session.find_by!(session_id: current_session_id)
+    Current.session.signin_by(user)
   end
 end

--- a/app/controllers/concerns/google_openid_connect.rb
+++ b/app/controllers/concerns/google_openid_connect.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module GoogleOpenIdConnect
+  extend ActiveSupport::Concern
+
+  included do
+    # rubocop:disable Rails/LexicallyScopedActionFilter
+    protect_from_forgery except: :create
+    skip_before_action :set_current_state, only: :create
+    before_action :protect_id_token_forgery, only: :create
+    # rubocop:enable Rails/LexicallyScopedActionFilter
+  end
+
+  private
+
+  def authenticated_google_id
+    google_client_id = ENV['GOOGLE_OPENID_CONNECT_CLIENT_ID']
+    payload = Google::Auth::IDTokens.verify_oidc(params[:credential], aud: google_client_id)
+  rescue StandardError => e
+    # See: https://www.rubydoc.info/github/google/google-auth-library-ruby/Google%2FAuth%2FIDTokens.verify_oidc
+    # See: https://github.com/googleapis/google-auth-library-ruby/blob/main/test/id_tokens/verifier_test.rb
+    reset_session
+    raise ActionController::InvalidAuthenticityToken(e.full_message)
+  else
+    # See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+    payload['sub']
+  end
+
+  def protect_id_token_forgery
+    # See: https://developers.google.com/identity/gsi/web/guides/verify-google-id-token?hl=ja
+    if cookies['g_csrf_token'].blank? || params[:g_csrf_token].blank? || cookies['g_csrf_token'] != params[:g_csrf_token]
+      reset_session
+      raise ActionController::InvalidAuthenticityToken
+    end
+
+    # See: https://developers.google.com/identity/openid-connect/openid-connect?hl=ja#state-param
+    begin
+      authenticated_session = Session.find_by!(token: params[:state]).destroy!
+    rescue ActiveRecord::ActiveRecordError => e
+      reset_session
+      raise ActionController::InvalidAuthenticityToken(e.full_message)
+    end
+
+    user = authenticated_session.user
+    @anonymous_user = user unless user&.registered?
+  end
+
+  def anonymous_user
+    @anonymous_user
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
+  include GoogleOpenIdConnect
+
   def create
+    user = User.find_by_hash_google_id(authenticated_google_id)
+
+    if user
+      signin_by(user)
+
+      redirect_to user_url(id: user.id), notice: 'ログインしました。'
+    else
+      redirect_to root_url, alert: 'ログインできませんでした。'
+    end
   end
 end

--- a/app/controllers/users/profiles_controller.rb
+++ b/app/controllers/users/profiles_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Users::ProfilesController < ApplicationController
+  before_action :require_answerd_to_survey_profile_and_unregistered_user
+  before_action :redirect_to_after_signin_url_if_registered_user?
+
   def show
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  include GoogleOpenIdConnect
+
   def show
   end
 
   def create
+    registered_user = User.find_by_hash_google_id(authenticated_google_id)
+    if registered_user
+      signin_by(registered_user)
+
+      redirect_to user_url(id: registered_user.id), notice: 'ログインしました。'
+    else
+      anonymous_user.register(authenticated_google_id)
+      signin_by(anonymous_user)
+
+      redirect_to user_url(id: anonymous_user.id), notice: '会員登録しました。'
+    end
   end
 
   def destroy

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class WelcomeController < ApplicationController
+  before_action :redirect_to_after_signin_url_if_registered_user?
+
   def index
   end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
 class Current < ActiveSupport::CurrentAttributes
-  attribute :user
+  attribute :session, :user
+
+  def session=(session)
+    super
+    self.user = session.user
+  end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Session < ActiveRecord::SessionStore::Session
+  belongs_to :user, optional: true
+
+  before_create do
+    self.token = SecureRandom.hex(32)
+  end
+
+  def signin_by(user)
+    raise ActiveRecord::RecordNotFound unless user&.id
+
+    update_column(:user_id, user.id) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,23 @@
 class User < ApplicationRecord
   has_one :profile, dependent: :destroy
   has_many :answers, dependent: :destroy
+  has_many :sessions, dependent: :destroy
+
+  validates :google_id, uniqueness: true, allow_nil: true # rubocop:disable Rails/UniqueValidationWithoutIndex
+
+  def self.find_by_hash_google_id(google_id)
+    hash = Digest::SHA512.hexdigest(google_id)
+
+    find_by(google_id: hash)
+  end
+
+  def register(google_id)
+    hash = Digest::SHA512.hexdigest(google_id)
+
+    update!(google_id: hash)
+  end
+
+  def registered?
+    !!google_id
+  end
 end

--- a/app/views/components/google_button/component.html.erb
+++ b/app/views/components/google_button/component.html.erb
@@ -1,4 +1,4 @@
-<div id="g_id_onload" data-client_id="<%= client_id %>" data-context="<%= context %>" data-ux_mode="redirect" data-login_uri="<%= redirect_url %>" data-auto_prompt="false">
+<div id="g_id_onload" data-client_id="<%= client_id %>" data-context="<%= context %>" data-ux_mode="redirect" data-state="<%= state %>" data-scope="openid" data-login_uri="<%= redirect_url %>" data-auto_prompt="false">
 </div>
 
 <div class="g_id_signin" data-type="standard" data-shape="rectangular" data-theme="outline" data-text="<%= caption %>" data-size="large" data-locale="ja" data-logo_alignment="left">

--- a/app/views/components/google_button/component.rb
+++ b/app/views/components/google_button/component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class GoogleButton::Component < ApplicationViewComponent
-  attr_reader :context
+  attr_reader :context, :state
 
-  def initialize(context:)
+  def initialize(context:, state:)
     super
     @context = context
+    @state = state
   end
 
   def client_id

--- a/app/views/users/profiles/show.html.erb
+++ b/app/views/users/profiles/show.html.erb
@@ -6,4 +6,4 @@
 
 <%= render(StartButton::Component.new(caption: 'やりなおす')) %>
 
-<%= render(GoogleButton::Component.new(context: 'signup')) %>
+<%= render(GoogleButton::Component.new(context: 'signup', state: Current.session.token)) %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -17,5 +17,5 @@
 
 <section>
   <h3>会員登録済みの方は、より正確に給付がいつ頃受けられるか、初回の失業認定日までの予定を確認できます。</h3>
-  <%= render(GoogleButton::Component.new(context: 'signin')) %>
+  <%= render(GoogleButton::Component.new(context: 'signin', state: Current.session.token)) %>
 </section>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,5 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  passw secret token _key crypt salt certificate otp ssn
+  passw secret token _key crypt salt certificate otp ssn state google_id
 ]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "OpenId"
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,4 @@
+Rails.application.config.session_store :active_record_store, key: '_employmate_session'
+Rails.application.config.after_initialize do
+  ActionDispatch::Session::ActiveRecordStore.session_class = Session
+end

--- a/db/migrate/20230502054227_create_sessions.rb
+++ b/db/migrate/20230502054227_create_sessions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSessions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false, index: { unique: true }
+      t.belongs_to :user, null: true, foreign_key: true
+      t.string :token, null: false
+      t.text :data
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_01_115534) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_02_054227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_115534) do
     t.index ["questionnaire_id"], name: "index_questions_on_questionnaire_id"
   end
 
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.bigint "user_id"
+    t.string "token", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "google_id"
     t.datetime "created_at", null: false
@@ -63,4 +75,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_01_115534) do
   add_foreign_key "answers", "users"
   add_foreign_key "profiles", "users"
   add_foreign_key "questions", "questionnaires"
+  add_foreign_key "sessions", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - node_modules:/opt/rails/node_modules
       - vscode:/root/.vscode-server
     env_file:
+      - .env
       - development.env
     environment:
       - HISTFILE=/histfile/.bash_history

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -23,3 +23,14 @@ Capybara.configure do |config|
   config.server_host = 'localhost'
   config.server_port = 8181
 end
+
+def session_private_id_from_cookie_value
+  session_private_id = nil
+  page.driver.with_playwright_page do |playwright|
+    cookie_value = playwright.context.cookies.find { |cookie| cookie['name'] == '_employmate_session' }['value']
+    # See: https://github.com/rack/rack-session/blob/main/lib/rack/session/abstract/id.rb#L30-L32
+    session_private_id = Rack::Session::SessionId.new(cookie_value).private_id
+  end
+
+  session_private_id
+end

--- a/spec/features/signin.feature
+++ b/spec/features/signin.feature
@@ -1,0 +1,21 @@
+Feature: Googleでログインする
+  Scenario: 初回分析回答が未回答のユーザーで「Googleでログイン」を試みる
+    Given 未ログインである
+
+    When ブラウザで"/"にアクセスする
+    Then ボタン"Googleでログイン"がある
+    And ボタン"はじめる"がある
+
+  Scenario: 初回分析回答直後のユーザーで「Googleでログイン」を試みる
+    Given ユーザー"初回分析回答直後"でログインする
+
+    When ブラウザで"/"にアクセスする
+    Then ボタン"Googleでログイン"がある
+    And ボタン"はじめる"がある
+
+  Scenario: すでにGoogleID連携済みのユーザーで「Googleでログイン」をする
+    Given ユーザー"GoogleID連携済み"でログインする
+
+    When ブラウザで"/"にアクセスする
+    Then ボタン"Googleでログイン"がない
+    And ボタン"はじめる"がない

--- a/spec/features/signup.feature
+++ b/spec/features/signup.feature
@@ -1,0 +1,21 @@
+Feature: Google で登録する
+  Scenario: 初回分析回答が未回答のユーザーで「Googleで登録」を試みる
+    Given 未ログインである
+
+    When ブラウザで"/users/123/profile"にアクセスする
+    Then ボタン"Googleで登録"がない
+    And ボタン"はじめる"がある
+
+  Scenario: 初回分析回答直後のユーザーで「Googleで登録」する
+    Given ユーザー"初回分析回答直後"でログインする
+
+    When ブラウザで"/users/:user_id/profile"にアクセスする
+    Then ボタン"Googleで登録"がある
+    And ボタン"はじめる"がない
+
+  Scenario: すでにGoogleID連携済みのユーザーで「Googleで登録」を試みる
+    Given ユーザー"GoogleID連携済み"でログインする
+
+    When ブラウザで"/users/:user_id/profile"にアクセスする
+    Then ボタン"Googleで登録"がない
+    And ボタン"はじめる"がない

--- a/spec/steps/application_steps.rb
+++ b/spec/steps/application_steps.rb
@@ -1,9 +1,30 @@
 step '未ログインである' do
-  Current.user = nil
+  expect(session_private_id_from_cookie_value).to eq nil
+end
+
+step 'ユーザー:nameでログインする' do |name|
+  case name
+  when '初回分析回答直後', 'GoogleID連携済み'
+    visit('/')
+    user = User.create!
+    user.create_profile!
+
+    user.register('fake-id') if name == 'GoogleID連携済み'
+
+    Session.find_by!(session_id: session_private_id_from_cookie_value).signin_by(user)
+  else
+    raise NotImplementedError, name
+  end
 end
 
 step 'ブラウザで:visit_pathにアクセスする' do |visit_path|
-  visit(visit_path)
+  case visit_path
+  when '/users/:user_id/profile'
+    user = Session.find_by!(session_id: session_private_id_from_cookie_value).user
+    visit(visit_path.sub(':user_id', user.id.to_s))
+  else
+    visit(visit_path)
+  end
 end
 
 step 'ページ本文に:contentとある' do |content|


### PR DESCRIPTION

## 概要（実現したいこと・ユーザーストーリー）

#35 , #36

### 関連するもの・やらないこと

単にログイン処理後の遷移ができるまでを実装する。遷移後のページは実装しない。
#39 の退会処理はこのプルリクエストではやらない。
またサーバーで払い出した session id を DB に保存することとなるが、1日以上経過したレコードの削除とリダイレクト処理は別の議題とする。

## 受け入れ条件

```
Feature: Google で登録する
  Scenario: 初回分析回答が未回答のユーザーで「Googleで登録」を試みる
    Given 未ログインである

    When ブラウザで"/users/123/profile"にアクセスする
    Then ボタン"Googleで登録"がない
    And ボタン"はじめる"がある

  Scenario: 初回分析回答直後のユーザーで「Googleで登録」する
    Given ユーザー"初回分析回答直後"でログインする

    When ブラウザで"/users/:user_id/profile"にアクセスする
    Then ボタン"Googleで登録"がある
    And ボタン"はじめる"がない

  Scenario: すでにGoogleID連携済みのユーザーで「Googleで登録」を試みる
    Given ユーザー"GoogleID連携済み"でログインする

    When ブラウザで"/users/:user_id/profile"にアクセスする
    Then ボタン"Googleで登録"がない
    And ボタン"はじめる"がない

```

```
Feature: Googleでログインする
  Scenario: 初回分析回答が未回答のユーザーで「Googleでログイン」を試みる
    Given 未ログインである

    When ブラウザで"/"にアクセスする
    Then ボタン"Googleでログイン"がある
    And ボタン"はじめる"がある

  Scenario: 初回分析回答直後のユーザーで「Googleでログイン」を試みる
    Given ユーザー"初回分析回答直後"でログインする

    When ブラウザで"/"にアクセスする
    Then ボタン"Googleでログイン"がある
    And ボタン"はじめる"がある

  Scenario: すでにGoogleID連携済みのユーザーで「Googleでログイン」をする
    Given ユーザー"GoogleID連携済み"でログインする

    When ブラウザで"/"にアクセスする
    Then ボタン"Googleでログイン"がない
    And ボタン"はじめる"がない

```

## 実装方針

- ログイン確認の際はセッション固定攻撃対策として reset_session する
- credential を [Google::Auth::IDTokens.verify_oidc](https://github.com/googleapis/google-auth-library-ruby/blob/main/lib/googleauth/id_tokens.rb#L167-L177) で検証し、ペイロードを取得する
- sub(subject claim) はハッシュ関数の実行結果のハッシュ値をDBに保存する
- ID トークンの偽造防止のため、Session に紐づくセキュリティトークンを発行してチェックする
  - そのため状態管理のための Session を DB に保存し、認証後は reset_session し、再利用できなくする
  - https://github.com/rails/activerecord-session_store
- ID トークン取得後の認証結果は https://github.com/lazaronixon/authentication-zero や https://techracho.bpsinc.jp/hachi8833/2017_08_01/43810 を参考にする

## チェックリスト

プルリクエストの状況を確認するためにチェックをいれてください。

- [x] E2E テストをしている
- [x] 必要に応じて単体テストをしている／E2E テストで網羅したため単体テストは不要
- [x] 静的解析ツールのチェックでエラーがない
- [x] セルフレビューの観点から問題ない
