### PR TITLE
行政機関の休日判定を実装する

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,3 +79,4 @@ jobs:
           bundle exec rails db:schema:load
           bundle exec rails db:seed
           bundle exec rspec
+          bundle exec rspec lib/national_government_organization_holiday/spec/

--- a/.rubocop/strict.yml
+++ b/.rubocop/strict.yml
@@ -48,3 +48,13 @@ RSpec/NestedGroups:
 
 RSpec/RepeatedExampleGroupBody:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+Lint/ScriptPermission:
+  Exclude:
+    - 'lib/national_government_organization_holiday/bin/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ gem "active_hash"
 gem 'activerecord-session_store'
 gem "googleauth"
 gem "holiday_japan"
+gem "national_government_organization_holiday", path: 'lib/national_government_organization_holiday'
 gem "newspaper"
 gem "rails-i18n", "~> 7.0.0"
 gem "view_component"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+PATH
+  remote: lib/national_government_organization_holiday
+  specs:
+    national_government_organization_holiday (1.0.0)
+      activesupport (~> 7.0)
+      holiday_japan (~> 1.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -358,6 +365,7 @@ DEPENDENCIES
   holiday_japan
   importmap-rails
   n_plus_one_control
+  national_government_organization_holiday!
   newspaper
   pg (~> 1.1)
   puma (~> 5.0)

--- a/lib/national_government_organization_holiday/.gitignore
+++ b/lib/national_government_organization_holiday/.gitignore
@@ -1,0 +1,12 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status
+Gemfile.lock

--- a/lib/national_government_organization_holiday/.rspec
+++ b/lib/national_government_organization_holiday/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/lib/national_government_organization_holiday/Gemfile
+++ b/lib/national_government_organization_holiday/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in national_government_organization_holiday.gemspec
+gemspec
+
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.0'

--- a/lib/national_government_organization_holiday/Rakefile
+++ b/lib/national_government_organization_holiday/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/national_government_organization_holiday/bin/console
+++ b/lib/national_government_organization_holiday/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'national_government_organization_holiday'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/lib/national_government_organization_holiday/bin/setup
+++ b/lib/national_government_organization_holiday/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/national_government_organization_holiday/lib/national_government_organization_holiday.rb
+++ b/lib/national_government_organization_holiday/lib/national_government_organization_holiday.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative 'national_government_organization_holiday/version'
+require_relative 'national_government_organization_holiday/integer_patch'

--- a/lib/national_government_organization_holiday/lib/national_government_organization_holiday/duration.rb
+++ b/lib/national_government_organization_holiday/lib/national_government_organization_holiday/duration.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'value'
+require 'active_support/duration'
+
+module NationalGovernmentOrganizationHoliday
+  class Duration < ActiveSupport::Duration
+    MIN_PLUS_DAYS = 1
+    MAX_PLUS_DAYS = 7
+
+    def initialize(plus_days)
+      raise TypeError unless plus_days.is_a?(Integer)
+      raise ArgumentError unless (MIN_PLUS_DAYS..MAX_PLUS_DAYS).cover?(plus_days)
+
+      # See: https://github.com/rails/rails/blob/v7.0.4.3/activesupport/lib/active_support/duration.rb#L166-L167
+      super(plus_days * SECONDS_PER_DAY, { days: plus_days }, true)
+    end
+
+    # See: https://github.com/rails/rails/blob/v7.0.4.3/activesupport/lib/active_support/core_ext/date/calculations.rb#L90-L98
+    def since(beginning_day)
+      weekdays = []
+
+      plus_days = parts[:days]
+      max_day = beginning_day.next_month
+      beginning_day.next.upto(max_day) do |next_day|
+        weekdays << next_day if Value.new(next_day).on_weekday?
+
+        break if weekdays.count == plus_days
+      end
+
+      weekdays.last
+    end
+  end
+end

--- a/lib/national_government_organization_holiday/lib/national_government_organization_holiday/integer_patch.rb
+++ b/lib/national_government_organization_holiday/lib/national_government_organization_holiday/integer_patch.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'duration'
+require 'active_support/core_ext/numeric/time'
+
+module NationalGovernmentOrganizationHoliday
+  module IntegerPatch
+    def national_gov_org_weekdays
+      NationalGovernmentOrganizationHoliday::Duration.new(self)
+    end
+    alias national_gov_org_weekday national_gov_org_weekdays
+  end
+end
+
+NationalGovernmentOrganizationHoliday::IntegerPatch.then do |mod|
+  Integer.send(:prepend, mod) unless Integer.include?(mod)
+end

--- a/lib/national_government_organization_holiday/lib/national_government_organization_holiday/value.rb
+++ b/lib/national_government_organization_holiday/lib/national_government_organization_holiday/value.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'holiday_japan'
+
+module NationalGovernmentOrganizationHoliday
+  class Value
+    def initialize(value)
+      @value = value
+    end
+
+    # See: https://elaws.e-gov.go.jp/document?lawid=363AC0000000091
+    def on_weekday?
+      return false if @value.on_weekend?
+      return false if on_new_year_holiday_season?
+      return false if @value.national_holiday?
+
+      true
+    end
+
+    def on_new_year_holiday_season?
+      current_year = @value.year
+      new_year = Date.new(current_year, 1, 1)..Date.new(current_year, 1, 3)
+      year_end = Date.new(current_year, 12, 29)..Date.new(current_year, 12, 31)
+
+      new_year.cover?(@value) || year_end.cover?(@value)
+    end
+  end
+end

--- a/lib/national_government_organization_holiday/lib/national_government_organization_holiday/version.rb
+++ b/lib/national_government_organization_holiday/lib/national_government_organization_holiday/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module NationalGovernmentOrganizationHoliday
+  VERSION = '1.0.0'
+end

--- a/lib/national_government_organization_holiday/national_government_organization_holiday.gemspec
+++ b/lib/national_government_organization_holiday/national_government_organization_holiday.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'lib/national_government_organization_holiday/version'
+
+Gem::Specification.new do |spec|
+  spec.name = 'national_government_organization_holiday'
+  spec.version = NationalGovernmentOrganizationHoliday::VERSION
+  spec.authors = ['Minoru Maeda']
+  spec.summary = '行政機関の休日を計算する。'
+  spec.required_ruby_version = '>= 3.2.2'
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (File.expand_path(f) == __FILE__) || f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor])
+    end
+  end
+  spec.bindir = 'exe'
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'activesupport', '~> 7.0'
+  spec.add_dependency 'holiday_japan', '~> 1.4'
+end

--- a/lib/national_government_organization_holiday/spec/national_government_organization_holiday_spec.rb
+++ b/lib/national_government_organization_holiday/spec/national_government_organization_holiday_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+RSpec.describe NationalGovernmentOrganizationHoliday do
+  describe 'Date#plus_with_duration' do
+    context '日曜日および土曜日を起算日とした場合' do
+      it '日曜日および土曜日は祝日でない' do
+        saturday = Date.new(2023, 4, 1)
+        expect(saturday.saturday?).to eq true
+        expect(saturday.national_holiday?).to eq false
+
+        sunday = Date.new(2023, 4, 2)
+        expect(sunday.sunday?).to eq true
+        expect(sunday.national_holiday?).to eq false
+      end
+
+      it '1開庁日を加算すると平日の月曜日になる' do
+        expected_value = Date.new(2023, 4, 3)
+        expect(Date.new(2023, 4, 1) + 1.national_gov_org_weekday).to eq expected_value
+        expect(Date.new(2023, 4, 2) + 1.national_gov_org_weekday).to eq expected_value
+
+        expect(expected_value.monday?).to eq true
+        expect(expected_value.national_holiday?).to eq false
+      end
+
+      it '2開庁日を加算すると平日の火曜日になる' do
+        expected_value = Date.new(2023, 4, 4)
+        expect(Date.new(2023, 4, 1) + 2.national_gov_org_weekdays).to eq expected_value
+        expect(Date.new(2023, 4, 2) + 2.national_gov_org_weekdays).to eq expected_value
+
+        expect(expected_value.tuesday?).to eq true
+        expect(expected_value.national_holiday?).to eq false
+      end
+    end
+
+    context '平日の12/29 - 1/3までを起算日とした場合' do
+      it '平日の1/1 - 1/3までの起算日に1開庁日を加算すると 1/4 になる' do
+        expected_value = Date.new(2019, 1, 4)
+        expect(Date.new(2019, 1, 1).tuesday?).to eq true
+        expect(Date.new(2019, 1, 1) + 1.national_gov_org_weekday).to eq expected_value
+        expect(Date.new(2019, 1, 2) + 1.national_gov_org_weekday).to eq expected_value
+        expect(Date.new(2019, 1, 3) + 1.national_gov_org_weekday).to eq expected_value
+      end
+
+      it '平日の12/29 - 12/31までの起算日に1開庁日を加算すると翌年の 1/4 になる' do
+        expected_value = Date.new(2022, 1, 4)
+        expect(Date.new(2021, 12, 29).wednesday?).to eq true
+        expect(Date.new(2021, 12, 29) + 1.national_gov_org_weekday).to eq expected_value
+        expect(Date.new(2021, 12, 30) + 1.national_gov_org_weekday).to eq expected_value
+        expect(Date.new(2021, 12, 31) + 1.national_gov_org_weekday).to eq expected_value
+      end
+
+      it '平日の12/28に1開庁日を加算すると翌年の 1/4 になる' do
+        expected_value = Date.new(2016, 1, 4)
+        expect(Date.new(2015, 12, 28).monday?).to eq true
+        expect(Date.new(2015, 12, 28) + 1.national_gov_org_weekday).to eq expected_value
+      end
+    end
+
+    context '国民の祝日に関する法律に規定する休日を起算日とした場合' do
+      it '黄金週間（2019/4/27 - 5/6）は10連休である' do
+        expect(Date.new(2019, 4, 26).friday?).to eq true
+        expect(Date.new(2019, 4, 26).national_holiday?).to eq false
+
+        expect(Date.new(2019, 4, 27).on_weekend?).to eq true
+        expect(Date.new(2019, 4, 28).on_weekend?).to eq true
+        expect(Date.new(2019, 4, 29).national_holiday?).to eq true
+        expect(Date.new(2019, 4, 30).national_holiday?).to eq true
+        expect(Date.new(2019, 5, 1).national_holiday?).to eq true
+        expect(Date.new(2019, 5, 2).national_holiday?).to eq true
+        expect(Date.new(2019, 5, 3).national_holiday?).to eq true
+        expect(Date.new(2019, 5, 4).on_weekend?).to eq true
+        expect(Date.new(2019, 5, 5).on_weekend?).to eq true
+        expect(Date.new(2019, 5, 6).national_holiday?).to eq true
+
+        expect(Date.new(2019, 5, 7).tuesday?).to eq true
+        expect(Date.new(2019, 5, 7).national_holiday?).to eq false
+      end
+
+      it '黄金週間直前の平日に1開庁日を加算すると黄金週間明けの平日になる' do
+        expect(Date.new(2019, 4, 26) + 1.national_gov_org_weekday).to eq Date.new(2019, 5, 7)
+      end
+
+      it '黄金週間の祝日に1開庁日を加算すると黄金週間明けの平日になる' do
+        expect(Date.new(2019, 4, 29) + 1.national_gov_org_weekday).to eq Date.new(2019, 5, 7)
+      end
+
+      it '黄金週間の国民の休日に1開庁日を加算すると黄金週間明けの平日になる' do
+        expect(Date.new(2019, 4, 30) + 1.national_gov_org_weekday).to eq Date.new(2019, 5, 7)
+      end
+
+      it '3連休前（土日祝）の金曜日に1開庁日を加算すると3連休明けの平日になる' do
+        expected_value = Date.new(2023, 1, 10)
+        expect(expected_value.national_holiday?).to eq false
+        expect(Date.new(2023, 1, 6) + 1.national_gov_org_weekday).to eq expected_value
+
+        expect(Date.new(2023, 1, 6).friday?).to eq true
+        expect(Date.new(2023, 1, 7).on_weekend?).to eq true
+        expect(Date.new(2023, 1, 8).on_weekend?).to eq true
+        expect(Date.new(2023, 1, 9).national_holiday?).to eq true
+      end
+
+      it '隔日の祝日前の平日に2開庁日を加算すると祝日明けの平日になる' do
+        expected_value = Date.new(1983, 5, 6)
+        expect(expected_value.national_holiday?).to eq false
+        expect(Date.new(1983, 5, 2) + 2.national_gov_org_weekdays).to eq expected_value
+
+        expect(Date.new(1983, 5, 2).monday?).to eq true
+        expect(Date.new(1983, 5, 3).national_holiday?).to eq true
+        expect(Date.new(1983, 5, 4).national_holiday?).to eq false
+        expect(Date.new(1983, 5, 5).national_holiday?).to eq true
+      end
+    end
+  end
+
+  describe 'Duration#initialize' do
+    it '整数以外は指定できない' do
+      expect { NationalGovernmentOrganizationHoliday::Duration.new(nil) }.to raise_error(TypeError)
+      expect { NationalGovernmentOrganizationHoliday::Duration.new('5') }.to raise_error(TypeError)
+      expect { NationalGovernmentOrganizationHoliday::Duration.new(5.0) }.to raise_error(TypeError)
+
+      expect { nil.national_gov_org_weekdays }.to raise_error(NoMethodError)
+      expect { '5'.national_gov_org_weekdays }.to raise_error(NoMethodError)
+      expect { 5.0.national_gov_org_weekdays }.to raise_error(NoMethodError)
+    end
+
+    it '7開庁日が上限である' do
+      expect(7.national_gov_org_weekdays).to be_truthy
+      expect { 8.national_gov_org_weekdays }.to raise_error(ArgumentError)
+    end
+
+    it '1開庁日が下限である' do
+      expect(1.national_gov_org_weekdays).to be_truthy
+      expect { 0.national_gov_org_weekdays }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/lib/national_government_organization_holiday/spec/spec_helper.rb
+++ b/lib/national_government_organization_holiday/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'national_government_organization_holiday'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION

## 概要（実現したいこと・ユーザーストーリー）

#34 にある行政機関の休日判定を実装し、失業認定日や雇用保険制度の給付金振込予定日の計算に利用する。

### 関連するもの・やらないこと

ひとまず単体で利用できるようにするだけ。失業認定日や雇用保険制度の給付金振込予定日の計算は別プルリクエストにする。

## 受け入れ条件

- 起算日の7日後を上限に、 https://elaws.e-gov.go.jp/document?lawid=363AC0000000091 を仕様が実装されていること
- `Date.new(2023, 2, 28) + 7.national_gov_org_weekdays` のように使えること

## 実装方針

- 日曜日及び土曜日 は [on_weekend?](https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-on_weekend-3F) を利用する
- 国民の祝日は http://masa16.github.io/holiday_japan/ で判断する
- 十二月二十九日から翌年の一月三日までの日は https://docs.ruby-lang.org/ja/latest/method/Range/i/cover=3f.html で判断する

## チェックリスト

プルリクエストの状況を確認するためにチェックをいれてください。

- [x] E2E テストをしている
- [x] 必要に応じて単体テストをしている／E2E テストで網羅したため単体テストは不要
- [x] 静的解析ツールのチェックでエラーがない
- [x] セルフレビューの観点から問題ない
