### PR TITLE
失業認定日の計算判定を実装する

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,4 +2,34 @@
 
 class Profile < ApplicationRecord
   belongs_to :user
+
+  def after_unemployed_on
+    unemployed_on.next_day
+  end
+
+  def issuanced_on_of_release_form
+    after_unemployed_on + 10.days
+  end
+
+  def draft_explanitory_seminar_on_for_employment_insurance
+    issuanced_on_of_release_form + 7.national_gov_org_weekdays
+  end
+
+  def first_unemployment_certification_on
+    fixed_first_unemployment_certification_on.presence ||
+      draft_unemployment_certification_on
+  end
+
+  def draft_unemployment_certification_on
+    beginning_day = draft_explanitory_seminar_on_for_employment_insurance + benefit_restriction_period
+    UnemploymentCertificationDay.new(beginning_day:).to_date
+  end
+
+  def benefit_restriction_period
+    return 0.days if unemployed_with_special_eligible?
+    return 0.days if unemployed_with_special_reason?
+
+    # TODO: [ 11, 12, 21, 22, 23, 31, 32, 33, 34 ].include?(reason_code_for_loss_of_employment)
+    2.months
+  end
 end

--- a/app/models/unemployment_certification_day.rb
+++ b/app/models/unemployment_certification_day.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class UnemploymentCertificationDay
+  CALENDAR_DAYS_OF_WEEK = 1..5
+  ONE_MONTH = 28.days
+  WAITING_PERIOD = 7.national_gov_org_weekdays
+
+  def initialize(beginning_day:, week_type: nil, day_of_week: nil)
+    if week_type && day_of_week
+      raise ArgumentError, day_of_week unless CALENDAR_DAYS_OF_WEEK.include?(day_of_week)
+
+      @value = next_month_date(beginning_day, week_type, day_of_week)
+    else
+      @value = (beginning_day + WAITING_PERIOD).beginning_of_week(:monday)
+    end
+  end
+
+  def to_date
+    @value
+  end
+
+  private
+
+  def next_month_date(beginning_day, week_type, day_of_week)
+    value_klass = NationalGovernmentOrganizationHoliday::Value
+
+    (beginning_day + ONE_MONTH).downto(beginning_day) do |date|
+      next unless week_type == WeekType.from_date(date) && day_of_week == date.wday
+
+      return date if value_klass.new(date).on_weekday?
+
+      date.prev_day.downto(date.prev_month) do |prev_date|
+        next unless value_klass.new(prev_date).on_weekday?
+
+        return prev_date
+      end
+    end
+  end
+end

--- a/app/models/week_type.rb
+++ b/app/models/week_type.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class WeekType
+  VALUES = 1..4
+  LAW_PROMULGATED_YEAR = 1974
+  LAW_PROMULGATED_WEEK_TYPE = VALUES.last
+
+  def initialize(value)
+    raise ArgumentError, value unless VALUES.include?(value)
+
+    @value = value
+  end
+
+  def add
+    if @value == VALUES.last
+      @value = 1
+    else
+      @value += 1
+    end
+  end
+
+  def to_i
+    @value
+  end
+
+  def to_s
+    @value
+  end
+
+  def self.beginning_of_year(target_year)
+    raise ArgumentError, target_year if target_year < LAW_PROMULGATED_YEAR
+
+    value = new(LAW_PROMULGATED_WEEK_TYPE)
+    (LAW_PROMULGATED_YEAR.next..target_year).step(1) do |year|
+      beginning_of_year = Date.new(year, 1, 1)
+
+      value.add if beginning_of_year.sunday?
+      value.add if beginning_of_year.monday? && Date.leap?(year - 1)
+    end
+
+    value.to_i
+  end
+
+  def self.from_date(date)
+    value = new(beginning_of_year(date.year))
+    (date.beginning_of_year.next_day..date).step(1) do |day|
+      value.add if day.sunday?
+    end
+
+    value.to_i
+  end
+end

--- a/db/migrate/20230519233751_change_column_to_profiles.rb
+++ b/db/migrate/20230519233751_change_column_to_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeColumnToProfiles < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :profiles, :first_unemployment_certification_on, :fixed_first_unemployment_certification_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_02_054227) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_19_233751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_02_054227) do
     t.boolean "unemployed_with_special_eligible", default: false
     t.boolean "unemployed_with_special_reason", default: false
     t.date "explanitory_seminar_on_for_employment_insurance"
-    t.date "first_unemployment_certification_on"
+    t.date "fixed_first_unemployment_certification_on"
     t.string "week_type_for_unemployment_certification"
     t.string "day_of_week_for_unemployment_certification"
     t.string "reason_code_for_loss_of_employment"

--- a/spec/models/unemployment_certification_day_spec.rb
+++ b/spec/models/unemployment_certification_day_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe UnemploymentCertificationDay, type: :model do
+  describe '.to_date' do
+    describe '暫定の失業認定日' do
+      context '起算日の7開庁日後が月曜日のとき' do
+        it '戻り値が月曜日である' do
+          beginning_day = Date.new(2023, 3, 15)
+          expected_value = described_class.new(beginning_day:).to_date
+
+          expect((beginning_day + 7.national_gov_org_weekdays).monday?).to eq true
+          expect(expected_value.monday?).to eq true
+          expect(expected_value).to eq Date.new(2023, 3, 27)
+        end
+      end
+
+      context '起算日の7開庁日後が火曜日のとき' do
+        it '戻り値が月曜日である' do
+          beginning_day = Date.new(2023, 3, 16)
+          expected_value = described_class.new(beginning_day:).to_date
+
+          expect((beginning_day + 7.national_gov_org_weekdays).tuesday?).to eq true
+          expect(expected_value.monday?).to eq true
+          expect(expected_value).to eq Date.new(2023, 3, 27)
+        end
+      end
+
+      context '起算日の7開庁日後が水曜日のとき' do
+        it '戻り値が月曜日である' do
+          beginning_day = Date.new(2023, 3, 17)
+          expected_value = described_class.new(beginning_day:).to_date
+
+          expect((beginning_day + 7.national_gov_org_weekdays).wednesday?).to eq true
+          expect(expected_value.monday?).to eq true
+          expect(expected_value).to eq Date.new(2023, 3, 27)
+        end
+      end
+
+      context '起算日の7開庁日後が木曜日のとき' do
+        it '戻り値が月曜日である' do
+          beginning_day = Date.new(2023, 3, 20)
+          expected_value = described_class.new(beginning_day:).to_date
+
+          expect((beginning_day + 7.national_gov_org_weekdays).thursday?).to eq true
+          expect(expected_value.monday?).to eq true
+          expect(expected_value).to eq Date.new(2023, 3, 27)
+        end
+      end
+
+      context '起算日の7開庁日後が金曜日のとき' do
+        it '戻り値が月曜日である' do
+          beginning_day = Date.new(2023, 3, 22)
+          expected_value = described_class.new(beginning_day:).to_date
+
+          expect((beginning_day + 7.national_gov_org_weekdays).friday?).to eq true
+          expect(expected_value.monday?).to eq true
+          expect(expected_value).to eq Date.new(2023, 3, 27)
+        end
+      end
+    end
+
+    describe '確定の失業認定日' do
+      context '起算日の28日後が開庁日のとき' do
+        it '戻り値が28日以内で最も未来の平日でかつ、指定した週の型と曜日が同じである' do
+          week_type = 1
+          day_of_week = 2
+          beginning_day = Date.new(2023, 3, 28)
+          expected_value = described_class.new(
+            week_type:, day_of_week:, beginning_day:
+          ).to_date
+
+          expect(expected_value).to eq Date.new(2023, 4, 25)
+          expect(WeekType.from_date(expected_value)).to eq week_type
+          expect(expected_value.wday).to eq day_of_week
+        end
+      end
+
+      context '起算日の28日後が閉庁日のとき' do
+        it '戻り値が28日以内で最も未来の開庁日でかつ、指定した週の型の開庁日に繰り上げされる' do
+          week_type = 2
+          day_of_week = 5
+          beginning_day = Date.new(2023, 4, 7)
+          expected_value = described_class.new(
+            week_type:, day_of_week:, beginning_day:
+          ).to_date
+
+          expect(expected_value).to eq Date.new(2023, 5, 2)
+          expect(WeekType.from_date(expected_value)).to eq week_type
+          expect(expected_value.wday).not_to eq day_of_week
+        end
+
+        it '戻り値が28日以内で最も未来の開庁日でかつ、指定した週の型のよりも前の週の開庁日に繰り上げされる' do
+          week_type = 4
+          day_of_week = 1
+          beginning_day = Date.new(2022, 2, 21)
+          expected_value = described_class.new(
+            week_type:, day_of_week:, beginning_day:
+          ).to_date
+
+          expect(expected_value).to eq Date.new(2022, 3, 18)
+          expect(WeekType.from_date(expected_value)).not_to eq week_type
+          expect(expected_value.wday).not_to eq day_of_week
+        end
+      end
+    end
+  end
+end

--- a/spec/models/week_type_spec.rb
+++ b/spec/models/week_type_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe WeekType, type: :model do
+  describe '.beginning_of_year' do
+    context '引数で与えられた年の1月1日の週が1型のとき' do
+      it '戻り値が 1 である' do
+        expect(described_class.beginning_of_year(2001)).to eq 1
+        expect(described_class.beginning_of_year(2005)).to eq 1
+        expect(described_class.beginning_of_year(2023)).to eq 1
+      end
+    end
+
+    context '引数で与えられた年の1月1日の週が2型のとき' do
+      it '戻り値が 2 である' do
+        expect(described_class.beginning_of_year(2006)).to eq 2
+        expect(described_class.beginning_of_year(2011)).to eq 2
+        expect(described_class.beginning_of_year(2029)).to eq 2
+      end
+    end
+
+    context '引数で与えられた年の1月1日の週が3型のとき' do
+      it '戻り値が 3 である' do
+        expect(described_class.beginning_of_year(2012)).to eq 3
+        expect(described_class.beginning_of_year(2016)).to eq 3
+        expect(described_class.beginning_of_year(2034)).to eq 3
+      end
+    end
+
+    context '引数で与えられた年の1月1日の週が4型のとき' do
+      it '戻り値が 4 である' do
+        expect(described_class.beginning_of_year(2000)).to eq 4
+        expect(described_class.beginning_of_year(2017)).to eq 4
+        expect(described_class.beginning_of_year(2022)).to eq 4
+      end
+    end
+
+    context '引数で与えられた年が雇用保険法公布前のとき' do
+      it 'ArgumentError が発生する' do
+        expect { described_class.beginning_of_year(1973) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '.from_date' do
+    describe '引数で与えられた日付が属する年の1月1日の型が1のとき' do
+      context '引数で与えられた日付が1型のとき' do
+        it '戻り値が 1 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2023, 1, 1))).to eq 1
+        end
+
+        it '戻り値が 1 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2023, 1, 2))).to eq 1
+        end
+      end
+
+      context '引数で与えられた日付が2型のとき' do
+        it '戻り値が 2 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2023, 2, 5))).to eq 2
+        end
+
+        it '戻り値が 2 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2023, 2, 10))).to eq 2
+        end
+      end
+
+      context '引数で与えられた日付が3型のとき' do
+        it '戻り値が 3 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2023, 3, 12))).to eq 3
+        end
+
+        it '戻り値が 3 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2023, 3, 14))).to eq 3
+        end
+      end
+
+      context '引数で与えられた日付が4型のとき' do
+        it '戻り値が 4 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2023, 4, 16))).to eq 4
+        end
+
+        it '戻り値が 4 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2023, 4, 21))).to eq 4
+        end
+      end
+    end
+
+    describe '引数で与えられた日付が属する年の1月1日の型が1でないとき' do
+      context '引数で与えられた日付が1型のとき' do
+        it '戻り値が 1 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2022, 1, 2))).to eq 1
+        end
+
+        it '戻り値が 1 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2022, 1, 7))).to eq 1
+        end
+      end
+
+      context '引数で与えられた日付が2型のとき' do
+        it '戻り値が 2 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2022, 12, 11))).to eq 2
+        end
+
+        it '戻り値が 2 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2022, 12, 13))).to eq 2
+        end
+      end
+
+      context '引数で与えられた日付が3型のとき' do
+        it '戻り値が 3 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2022, 11, 20))).to eq 3
+        end
+
+        it '戻り値が 3 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2022, 11, 23))).to eq 3
+        end
+      end
+
+      context '引数で与えられた日付が4型のとき' do
+        it '戻り値が 4 である（日曜日）' do
+          expect(described_class.from_date(Date.new(2022, 10, 30))).to eq 4
+        end
+
+        it '戻り値が 4 である（日曜日以外）' do
+          expect(described_class.from_date(Date.new(2022, 10, 31))).to eq 4
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

## 概要（実現したいこと・ユーザーストーリー）

#34 にある失業認定日の計算を実装する。

### 関連するもの・やらないこと

ひとまず単体で利用できるようにするだけ。失業認定日や雇用保険制度の給付金振込予定日の計算は別プルリクエストにする。

## 受け入れ条件

- 失業認定日の起算日の年の1月1日が週の何型かを算出する
  - 雇用保険法の公布年の1月1日を週の型が1と仮定する
  - 2023年1月1日は週の型が1で日曜日
  - 2024年1月1日は週の型が1で月曜日（1年は52週と1または2日のため、ずれていく）
- 確定した失業認定日の間隔は28日（4週間）となる
- 暫定の失業認定日は https://github.com/maeda-m/employmate/issues/22#issuecomment-1528934206 のとおり、雇用保険説明会日(暫定)に7 開庁日を加えた該当週の月曜日となる
- 暫定または確定した失業認定日が行政機関の休日の場合は前日となる
  - 前日が行政機関の休日の場合はさらに前日となる（以降、行政機関の開庁日まで繰り返す）

## 実装方針

- モデルとして実装する
- 行政機関の休日判定を利用する

## チェックリスト

プルリクエストの状況を確認するためにチェックをいれてください。

- [x] E2E テストをしている
- [x] 必要に応じて単体テストをしている／E2E テストで網羅したため単体テストは不要
- [x] 静的解析ツールのチェックでエラーがない
- [x] セルフレビューの観点から問題ない
