### PR TITLE
HTTP Strict-Transport-Security の設定を追加する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## 概要（実現したいこと・ユーザーストーリー）

#50

## 受け入れ条件

HSTS が設定されており、http でアクセスしてもクッキーにセッションIDが設定されないようになっていること。

## 実装方針

- https://api.rubyonrails.org/v7.0/classes/ActionDispatch/SSL.html